### PR TITLE
Use standard error logger instead of log4erl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ doc:
 	$(REBAR) doc skip_deps=true
 
 APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
-xmerl snmp public_key mnesia eunit syntax_tools compiler deps/log4erl deps/mochiweb
+xmerl snmp public_key mnesia eunit syntax_tools compiler
 COMBO_PLT = $(HOME)/.resource_discovery_dialyzer_plt
 
 check_plt: compile

--- a/rebar.config
+++ b/rebar.config
@@ -4,10 +4,5 @@
 {cover_enabled, true}.
 {erl_opts, [debug_info, fail_on_warning]}.
 
-{deps, [
-	 {'log4erl', ".*", {git, "git://github.com/ahmednawras/log4erl.git", "master"}}
-       ]}.    
-
-
 {post_hooks, [{compile, "cp ./src/sys.config ./ebin/sys.config"}]}.
 

--- a/src/rd_core.erl
+++ b/src/rd_core.erl
@@ -198,7 +198,7 @@ all_of_type_get(Type) ->
 %%-----------------------------------------------------------------------
 %%-spec sync_resources(node(), {LocalResourceTuples, TargetTypes, DeletedTuples}) -> ok.
 sync_resources(Node, {LocalResourceTuples, TargetTypes, DeletedTuples}) ->
-    log4erl:info("synch resources for node: ~p", [Node]),
+    error_logger:info_msg("synch resources for node: ~p", [Node]),
     {ok, FilteredRemotes} = gen_server:call({?SERVER, Node}, {sync_resources, {LocalResourceTuples, TargetTypes, DeletedTuples}}),
     rd_store:store_resource_tuples(FilteredRemotes),
     make_callbacks(FilteredRemotes),
@@ -256,12 +256,12 @@ init([]) ->
     {ok, #state{}}.
 
 handle_call({sync_resources, {Remotes, RemoteTargetTypes, RemoteDeletedTuples}}, _From, State) ->
-    log4erl:info("sync_resources, got remotes: ~p deleted: ~p", [Remotes, RemoteDeletedTuples]),
+    error_logger:info_msg("sync_resources, got remotes: ~p deleted: ~p", [Remotes, RemoteDeletedTuples]),
     LocalResourceTuples = rd_store:get_local_resource_tuples(),
     TargetTypes = rd_store:get_target_resource_types(),
     FilteredRemotes = filter_resource_tuples_by_types(TargetTypes, Remotes),
     FilteredLocals = filter_resource_tuples_by_types(RemoteTargetTypes, LocalResourceTuples),
-    log4erl:info("sync_resources, storing filted remotes: ~p", [FilteredRemotes]),
+    error_logger:info_msg("sync_resources, storing filted remotes: ~p", [FilteredRemotes]),
     rd_store:store_resource_tuples(FilteredRemotes),
     [rd_store:delete_resource_tuple(DR) || DR <- RemoteDeletedTuples],
     make_callbacks(FilteredRemotes),
@@ -327,14 +327,14 @@ handle_cast(trade_resources, State) ->
     rd_store:delete_deleted_resource_tuple(),
     {noreply, State};
 handle_cast({trade_resources, {ReplyTo, {Remotes, RemoteDeletedTuples}}}, State) ->
-    log4erl:info("trade_resources, got remotes ~p: deleted: ~p", [Remotes, RemoteDeletedTuples]),
+    error_logger:info_msg("trade_resources, got remotes ~p: deleted: ~p", [Remotes, RemoteDeletedTuples]),
     Locals = rd_store:get_local_resource_tuples(),
     LocalsDeleted = rd_store:get_deleted_resource_tuples(),
     TargetTypes = rd_store:get_target_resource_types(),
     FilteredRemotes = filter_resource_tuples_by_types(TargetTypes, Remotes),
-    log4erl:info("got remotes and filtered ~p", [FilteredRemotes]),
+    error_logger:info_msg("got remotes and filtered ~p", [FilteredRemotes]),
     rd_store:store_resource_tuples(FilteredRemotes),
-    log4erl:info("trade_resources, deleting ~p", [RemoteDeletedTuples]),
+    error_logger:info_msg("trade_resources, deleting ~p", [RemoteDeletedTuples]),
     [rd_store:delete_resource_tuple(DR) || DR <- RemoteDeletedTuples],
     make_callbacks(FilteredRemotes),
     reply(ReplyTo, {Locals, LocalsDeleted}),

--- a/src/rd_heartbeat.erl
+++ b/src/rd_heartbeat.erl
@@ -100,7 +100,7 @@ handle_info(timeout, State = #state{frequency = Frequency}) ->
 %% Returns: any (ignored by gen_server)
 %%--------------------------------------------------------------------
 terminate(Reason, _State) ->
-    log4erl:info("stoppping resource discovery hearbeat ~p", [Reason]),
+    error_logger:info_msg("stoppping resource discovery hearbeat ~p", [Reason]),
     ok.
 
 %%--------------------------------------------------------------------

--- a/src/rd_util.erl
+++ b/src/rd_util.erl
@@ -34,7 +34,7 @@ do_until(F, [H|T]) ->
 %% @doc Pings a node and returns only after the net kernal distributes the nodes.
 -spec sync_ping(node(), timeout()) -> pang | pong.
 sync_ping(Node, Timeout) ->
-    log4erl:info("pinging node: ~p", [Node]),
+    error_logger:info_msg("pinging node: ~p", [Node]),
     case net_adm:ping(Node) of
         pong ->
 	    Resp = 
@@ -93,11 +93,11 @@ get_env(Key, Default) ->
 get_remote_nodes(Node) ->
     try
 	Nodes = rpc:call(Node, erlang, nodes, []),
-	log4erl:info("contact node has ~p", [Nodes]),
+	error_logger:info_msg("contact node has ~p", [Nodes]),
 	Nodes
     catch
 	_C:E ->
-	    log4erl:info("failed to connect to contact node ~p", [Node]),
+	    error_logger:info_msg("failed to connect to contact node ~p", [Node]),
 	    throw(E)
     end.
 

--- a/src/resource_discovery.app.src
+++ b/src/resource_discovery.app.src
@@ -25,8 +25,7 @@
   {applications,
    [
     kernel, 
-    stdlib,
-    log4erl
+    stdlib
    ]},
 
   % configuration parameters
@@ -35,8 +34,7 @@
   % The M F A to start this application.
   {mod, {resource_discovery,
 	 [
-	  {heartbeat_frequency, 60000},
-	  {log4erl_config, "etc/log4erl.conf"}
+	  {heartbeat_frequency, 60000}
 	 ]}}
  ]
 }.

--- a/test/resource_discovery_tests.erl
+++ b/test/resource_discovery_tests.erl
@@ -133,11 +133,11 @@ run_notify(_Pid) ->
 %% function which is called when event happens
 %% for test we only care when resource 'e' becomes available
 resource_up({e, R}) ->
-    log4erl:info("resource is up ~p: ~p", [e, R]),
+    error_logger:info_msg("resource is up ~p: ~p", [e, R]),
     %% callback happend, set state in loop process, so it could be verified in test
     set_state(true);   
 resource_up(Other) ->
-    log4erl:info("resource is up, dont' care: ~p", [Other]).
+    error_logger:info_msg("resource is up, dont' care: ~p", [Other]).
 
 get_state() ->
     notify_loop_process ! {self(), get},


### PR DESCRIPTION
This is the change I made to use the standard erlang logger instead of log4erl, which has the mochiweb 1.5 dependency. This effectlively gets rid of all dependencies in resource_discovery :)
